### PR TITLE
Starting point for ATTAINS functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+.DS_Store
+**/.DS_Store

--- a/TADA_funx.Rproj
+++ b/TADA_funx.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/new_tada_functions.Rmd
+++ b/new_tada_functions.Rmd
@@ -1,0 +1,69 @@
+---
+title: "New TADA Functions"
+author: "ROSSyndicate"
+date: "`r Sys.Date()`"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    theme: paper
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE,
+                      warning = FALSE,
+                      error = FALSE,
+                      message = FALSE)
+
+# load in all necessary packages
+source("src/setup.R")
+#... currently: "TADA", "tidyverse", "sf", "TADA", "urltools", "geojsonsf", "leaflet", "viridis"
+```
+
+This RMD describes a suite of {{**currently** **in-development**}} functions to fulfill the following TADA Module 2 goal:
+
+*Match WQP sites with ATTAINS assessment units. Assist user with reviewing sites and AUs on a map and deciding to keep or exclude sites (systematically first, maybe using catchments as a buffer around the AU points/line/polygons for consistency, and then let users make manual edits to include or exclude sites (main requirement)). Consider adding option to create new AUs for new areas where WQP sites are available but no AU exists yet (secondary requirement). Output is a simple spreadsheet linking ATTAINS AU IDs with WQP Location IDs.*  
+
+### A note about ATTAINS
+
+ATTAINS is an online platform that organizes and combines each state’s Clean Water Act reporting data into a single data repository. The geospatial component of ATTAINS includes spatial representations of each state’s assessment units as well as their assigned designated uses, their most recent EPA reporting category (i.e., their impairment status), their impaired designated uses, and the parameter(s) causing the impairment.
+
+Within an assessment unit, the water quality standards remain the same and all water features are assessed as one entity. Depending on the state, these assessment units can be a specific point along a river, a river reach, an entire river, or even an entire watershed. (In other words, assessment units can take the form of point, line, and area features, or some combination of all of them.) Moreover, it is possible that some assessment units are not geospatially referenced at all, meaning they are not captured in the ATTAINS geospatial database.
+
+## `TADA_GetATTAINS()`
+
+This function pulls in ATTAINS data from the [EPA's ATTAINS Assessment Geospatial Service](https://www.epa.gov/waterdata/get-data-access-public-attains-data#AttainsGeo) and links it to TADA-pulled Water Quality Portal (WQP) observations. For the function to work properly, the input data frame must have - at a minimum - WQP observation coordinates in "TADA.LongitudeMeasure" and "TADA.LatitudeMeasure" columns. This function plays nice with TADA's current `TADA_DataRetrieval()` function.
+
+The function returns a data frame containing the original TADA WQP dataset, plus new columns representing the ATTAINS assessment unit(s) that fall within the same NHDPlus HR catchment as them. This means that it is possible for a single TADA WQP observation to have multiple ATTAINS assessment units linked to it and subsequently more than one row of data. Such WQP observations can be identified using the \`index\` column.
+
+```{r}
+source("src/TADA_GetATTAINS.R")
+
+# For testing, make some TADA_DataRetrieval calls:
+TADA_dataset_1 <- TADA_DataRetrieval(startDate = "2020-06-01",
+                                   endDate = "2020-08-05",
+                                   characteristicName = "pH",
+                                   countycode = "US:51:069")
+TADA_dataset_2 <- TADA_DataRetrieval(startDate = "2020-06-01",
+                                   endDate = "2020-08-05",
+                                   characteristicName = "pH",
+                                   countycode = "US:08:069")
+
+test_it_once <- TADA_GetATTAINS(data = TADA_dataset_1)
+
+test_it_twice <- TADA_GetATTAINS(data = TADA_dataset_2)
+```
+
+## `TADA_ViewATTAINS()`
+
+This function visualizes the raw ATTAINS features that are linked to the TADA WQP observations. (Essentially, this maps the same data listed from running `TADA_GetATTAINS()`.) For the function to work properly, the input data frame must have - at a minimum - WQP observation coordinates in "TADA.LongitudeMeasure" and "TADA.LatitudeMeasure" columns. This function also plays nice with TADA's current `TADA_DataRetrieval()` function.
+
+```{r}
+source("src/TADA_ViewATTAINS.R")
+
+TADA_ViewATTAINS(data = TADA_dataset_1)
+```
+
+```{r}
+TADA_ViewATTAINS(data = TADA_dataset_2)
+```

--- a/new_tada_functions.Rmd
+++ b/new_tada_functions.Rmd
@@ -18,7 +18,9 @@ knitr::opts_chunk$set(echo = FALSE,
 # load in all necessary packages
 source("src/setup.R")
 #... currently: "TADA", "tidyverse", "sf", "TADA", "urltools", "geojsonsf", "leaflet", "viridis"
-```
+
+# load library for testing
+library(TADA)
 
 This RMD describes a suite of {{**currently** **in-development**}} functions to fulfill the following TADA Module 2 goal:
 

--- a/new_tada_functions.Rmd
+++ b/new_tada_functions.Rmd
@@ -22,7 +22,7 @@ source("src/setup.R")
 
 This RMD describes a suite of {{**currently** **in-development**}} functions to fulfill the following TADA Module 2 goal:
 
-*Match WQP sites with ATTAINS assessment units. Assist user with reviewing sites and AUs on a map and deciding to keep or exclude sites (systematically first, maybe using catchments as a buffer around the AU points/line/polygons for consistency, and then let users make manual edits to include or exclude sites (main requirement)). Consider adding option to create new AUs for new areas where WQP sites are available but no AU exists yet (secondary requirement). Output is a simple spreadsheet linking ATTAINS AU IDs with WQP Location IDs.*  
+*Match WQP sites with ATTAINS assessment units. Assist user with reviewing sites and Assessment Units (AUs) on a map and deciding to keep or exclude sites (systematically first, maybe using catchments as a buffer around the AU points/line/polygons for consistency, and then let users make manual edits to include or exclude sites (main requirement)). Consider adding option to create new AUs for new areas where WQP sites are available but no AU exists yet (secondary requirement). Output is a simple spreadsheet linking ATTAINS AU IDs with WQP Location IDs.*  
 
 ### A note about ATTAINS
 

--- a/src/TADA_GetATTAINS.R
+++ b/src/TADA_GetATTAINS.R
@@ -1,0 +1,72 @@
+#' Link catchment-based ATTAINS assessment unit data to water quality observations imported via `TADA_DataRetrieval()`.
+#' 
+#' @param data A dataframe created by `TADA_DataRetrieval()`. Requires columns "TADA.LongitudeMeasure" and "TADA.LatitudeMeasure".
+#' 
+#' @return The original `TADA_DataRetrieval()` dataframe with additional columns associated with the ATTAINS assessment unit data. 
+#' 
+#' @seealso [TADA_DataRetrieval()]
+
+TADA_GetATTAINS <- function(data){
+  
+  suppressWarnings({
+    
+    sf::sf_use_s2(FALSE)
+    
+    TADA_DataRetrieval_data <- data %>%
+      # Use the USGS projection code (also used in AquaSat) to improve CRS in future iteration of the function!
+      sf::st_as_sf(., coords = c("TADA.LongitudeMeasure", "TADA.LatitudeMeasure"), crs = 4326) %>%
+      # add index for identifying obs with more than one ATTAINS assessment unit
+      tibble::rowid_to_column(var = "index")
+    
+    # base URL for  ATTAINS catchment API
+    baseurl <- "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/3/query?"
+    
+    # bounding box (with some wiggle) of TADA data
+    bbox <- TADA_DataRetrieval_data %>% 
+      sf::st_buffer(0.001) %>% 
+      sf::st_bbox(TADA_DataRetrieval_data)
+    
+    # convert bounding box to characters
+    bbox <- toString(bbox) %>% 
+      # encode for use within the API URL
+      urltools::url_encode(.)
+    
+    # EPSG for CRS used by TADA data. THIS NEEDS TO BE IMPROVED!
+    epsg <- sf::st_crs(TADA_DataRetrieval_data)$epsg
+    
+    # set all necessary parameters for the query
+    query <- urltools::param_set(baseurl, key = "geometry", value = bbox) %>%
+      urltools::param_set(key = "inSR", value = epsg) %>%
+      urltools::param_set(key = "resultRecordCount", value = 5000) %>%
+      urltools::param_set(key = "spatialRel", value = "esriSpatialRelIntersects") %>%
+      urltools::param_set(key = "f", value = "geojson") %>%
+      urltools::param_set(key = "outFields", value = "*") %>%
+      urltools::param_set(key = "geometryType", value = "esriGeometryEnvelope") %>%
+      urltools::param_set(key = "returnGeometry", value = "true") %>%
+      urltools::param_set(key = "returnTrueCurves", value = "false") %>%
+      urltools::param_set(key = "returnIdsOnly", value = "false") %>%
+      urltools::param_set(key = "returnCountOnly", value = "false") %>%
+      urltools::param_set(key = "returnZ", value = "false") %>%
+      urltools::param_set(key = "returnM", value = "false") %>%
+      urltools::param_set(key = "returnDistinctValues", value = "false") %>%
+      urltools::param_set(key = "returnExtentOnly", value = "false") %>%
+      urltools::param_set(key = "featureEncoding", value = "esriDefault")
+    
+    # grab the geospatial data!
+    nearby_catchments <- geojsonsf::geojson_sf(query) %>%
+      # remove unnecessary columns:
+      dplyr::select(-c(OBJECTID, GLOBALID)) %>%
+      .[TADA_DataRetrieval_data,] %>%
+      dplyr::rename_with(~ paste0("ATTAINS.", .), dplyr::everything()) %>%
+      dplyr::distinct(.keep_all = TRUE)
+    
+    # join TADA sf features to the ATTAINS catchment feature(s) they land on:
+    TADA_with_ATTAINS <- TADA_DataRetrieval_data %>%
+      sf::st_join(., nearby_catchments) %>%
+      sf::st_drop_geometry()
+    
+    return(TADA_with_ATTAINS)
+    
+  })
+  
+}

--- a/src/TADA_GetATTAINS.R
+++ b/src/TADA_GetATTAINS.R
@@ -56,7 +56,7 @@ TADA_GetATTAINS <- function(data){
     nearby_catchments <- geojsonsf::geojson_sf(query) %>%
       # remove unnecessary columns:
       dplyr::select(-c(OBJECTID, GLOBALID)) %>%
-      .[TADA_DataRetrieval_data,] %>%
+      .[TADA_DataRetrieval_data, ] %>%
       dplyr::rename_with(~ paste0("ATTAINS.", .), dplyr::everything()) %>%
       dplyr::distinct(.keep_all = TRUE)
     

--- a/src/TADA_ViewATTAINS.R
+++ b/src/TADA_ViewATTAINS.R
@@ -45,7 +45,7 @@ TADA_ViewATTAINS <- function(data){
         urltools::param_set(key = "returnZ", value = "false") %>%
         urltools::param_set(key = "returnM", value = "false") %>%
         urltools::param_set(key = "returnDistinctValues", value = "false") %>%
-        urltools::  param_set(key = "returnExtentOnly", value = "false") %>%
+        urltools::param_set(key = "returnExtentOnly", value = "false") %>%
         urltools::param_set(key = "featureEncoding", value = "esriDefault")
       
       final_sf <- geojsonsf::geojson_sf(query)

--- a/src/TADA_ViewATTAINS.R
+++ b/src/TADA_ViewATTAINS.R
@@ -1,0 +1,157 @@
+#' Finds ATTAINS assessment unit data within the same catchment as water quality observations imported via `TADA_DataRetrieval()`.
+#' 
+#' @param data A dataframe, often created by `TADA_DataRetrieval()`. Requires columns "TADA.LongitudeMeasure" and "TADA.LatitudeMeasure".
+#' 
+#' @return A leaflet map visualizing the TADA water quality observations and the linked ATTAINS assessment units. 
+#' 
+#' @seealso [TADA_DataRetrieval()]
+#' 
+TADA_ViewATTAINS <- function(data){
+  
+  suppressWarnings({
+    
+    sf::sf_use_s2(FALSE)
+    
+    TADA_DataRetrieval_data <- data %>%
+      # Use the USGS projection code (also used in AquaSat) to improve CRS in future iteration of the function!
+      sf::st_as_sf(., coords = c("TADA.LongitudeMeasure", "TADA.LatitudeMeasure"), crs = 4326) 
+    
+    download_attains <- function(baseurl){
+      # bounding box (with some wiggle) of TADA data
+      bbox <- TADA_DataRetrieval_data %>% 
+        sf::st_buffer(0.001) %>% 
+        sf::st_bbox(TADA_DataRetrieval_data)
+      
+      # convert bounding box to characters
+      bbox <- toString(bbox) %>% 
+        # encode for use within the API URL
+        urltools::url_encode(.)
+      
+      # EPSG for CRS used by TADA data. THIS NEEDS TO BE IMPROVED!
+      epsg <- sf::st_crs(TADA_DataRetrieval_data)$epsg
+      
+      # set all necessary parameters for the query
+      query <- urltools::param_set(baseurl, key = "geometry", value = bbox) %>%
+        urltools::param_set(key = "inSR", value = epsg) %>%
+        urltools::param_set(key = "resultRecordCount", value = 5000) %>%
+        urltools::param_set(key = "spatialRel", value = "esriSpatialRelIntersects") %>%
+        urltools::param_set(key = "f", value = "geojson") %>%
+        urltools::param_set(key = "outFields", value = "*") %>%
+        urltools::param_set(key = "geometryType", value = "esriGeometryEnvelope") %>%
+        urltools::param_set(key = "returnGeometry", value = "true") %>%
+        urltools::param_set(key = "returnTrueCurves", value = "false") %>%
+        urltools::param_set(key = "returnIdsOnly", value = "false") %>%
+        urltools::param_set(key = "returnCountOnly", value = "false") %>%
+        urltools::param_set(key = "returnZ", value = "false") %>%
+        urltools::param_set(key = "returnM", value = "false") %>%
+        urltools::param_set(key = "returnDistinctValues", value = "false") %>%
+        urltools::  param_set(key = "returnExtentOnly", value = "false") %>%
+        urltools::param_set(key = "featureEncoding", value = "esriDefault")
+      
+      final_sf <- geojsonsf::geojson_sf(query)
+      
+      return(final_sf)
+      
+    }
+    
+    # grab the geospatial data!
+    nearby_catchments <- download_attains(baseurl = "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/3/query?") %>%
+      # remove unnecessary columns:
+      dplyr::select(-c(OBJECTID, GLOBALID)) %>%
+      .[TADA_DataRetrieval_data,] %>%
+      dplyr::rename_with(~ paste0("ATTAINS.", .), dplyr::everything())
+    
+    # join TADA sf features to the ATTAINS catchment feature(s) they land on:
+    TADA_with_ATTAINS <- TADA_DataRetrieval_data %>%
+      sf::st_join(., nearby_catchments) %>%
+      sf::st_drop_geometry() 
+    
+    # POINT FEATURES
+    try(points <- download_attains(baseurl = "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/0/query?") %>%
+          .[nearby_catchments,])
+    try(points_mapper <- tibble::tibble(assessmentunitidentifier = unique(lines$assessmentunitidentifier),
+                                        colors = inferno(length(unique(lines$assessmentunitidentifier)))) %>%
+          dplyr::inner_join(points, by = "assessmentunitidentifier") %>%
+          sf::st_as_sf())
+    
+    # LINE FEATURES
+    try(lines <- download_attains(baseurl = "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1/query?") %>%
+          .[nearby_catchments,] %>%
+          distinct(assessmentunitidentifier, .keep_all = TRUE))
+    try(lines_mapper <- tibble(assessmentunitidentifier = unique(lines$assessmentunitidentifier),
+                               colors = viridis::inferno(length(unique(lines$assessmentunitidentifier)))) %>%
+          dplyr::inner_join(lines, by = "assessmentunitidentifier") %>%
+          sf::st_as_sf())
+    
+    # AREA FEATURES
+    try(areas <- download_attains(baseurl = "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/2/query?") %>%
+          .[nearby_catchments,])
+    try(areas_mapper <- tibble::tibble(assessmentunitidentifier = unique(areas$assessmentunitidentifier),
+                                       colors = viridis::inferno(length(unique(areas$assessmentunitidentifier)))) %>%
+          dplyr::inner_join(areas, by = "assessmentunitidentifier") %>%
+          sf::st_as_sf())
+    
+    sumdat <- data  %>% dplyr::group_by(MonitoringLocationIdentifier, 
+                                        MonitoringLocationName, TADA.LatitudeMeasure, TADA.LongitudeMeasure) %>% 
+      dplyr::summarize(Sample_Count = length(unique(ResultIdentifier)), 
+                       Visit_Count = length(unique(ActivityStartDate)), 
+                       Parameter_Count = length(unique(TADA.CharacteristicName)), 
+                       Organization_Count = length(unique(OrganizationIdentifier)))
+    
+    
+    # Map of WQP points
+    map <- leaflet::leaflet() %>% 
+      leaflet::addProviderTiles("Esri.WorldTopoMap", 
+                                group = "World topo",
+                                options = leaflet::providerTileOptions(updateWhenZooming = FALSE, 
+                                                                       updateWhenIdle = TRUE)) %>% 
+      leaflet::clearShapes() %>% 
+      leaflet::fitBounds(lng1 = min(sumdat$TADA.LongitudeMeasure), 
+                         lat1 = min(sumdat$TADA.LatitudeMeasure), 
+                         lng2 = max(sumdat$TADA.LongitudeMeasure), 
+                         lat2 = max(sumdat$TADA.LatitudeMeasure)) %>% 
+      leaflet.extras::addResetMapButton() %>% 
+      leaflet::addCircleMarkers(data = sumdat, 
+                                lng = ~TADA.LongitudeMeasure, lat = ~TADA.LatitudeMeasure, 
+                                color = "black", fillColor = "grey", 
+                                fillOpacity = 0.7, stroke = TRUE, weight = 1.5, 
+                                radius = 5, 
+                                popup = paste0("Site ID: ", sumdat$MonitoringLocationIdentifier, 
+                                               "<br> Site Name: ", sumdat$MonitoringLocationName, 
+                                               "<br> Measurement Count: ", sumdat$Sample_Count, 
+                                               "<br> Visit Count: ", sumdat$Visit_Count, 
+                                               "<br> Characteristic Count: ", sumdat$Parameter_Count))
+    # Add ATTAINS lines features (if they exist):
+    try(map <- map %>%
+          leaflet::addPolylines(data = lines_mapper,
+                                color = ~colors,
+                                weight = 2.5,
+                                popup = paste0("Assessment Unit Name: ", lines_mapper$assessmentunitname, 
+                                               "<br> Assessment Unit ID: ", lines_mapper$assessmentunitidentifier,
+                                               "<br> Status: ", lines_mapper$overallstatus)))
+    # Add ATTAINS area features (if they exist):
+    try(map <- map %>%
+          leaflet::addPolygons(data = areas_mapper,
+                               color = ~colors,
+                               weight = 2.5,
+                               popup = paste0("Assessment Unit Name: ", areas_mapper$assessmentunitname, 
+                                              "<br> Assessment Unit ID: ", areas_mapper$assessmentunitidentifier,
+                                              "<br> Status: ", areas_mapper$overallstatus)))
+    
+    # Add ATTAINS point features (if they exist):
+    try(map <- map %>%
+          leaflet::addCircleMarkers(data = points_mapper, 
+                                    lng = ~TADA.LongitudeMeasure, lat = ~TADA.LatitudeMeasure, 
+                                    color = ~colors, fillColor = ~colors, 
+                                    fillOpacity = 0.7, stroke = TRUE, weight = 1.5, 
+                                    radius = 5, 
+                                    popup = paste0("Assessment Unit Name: ", areas_mapper$assessmentunitname, 
+                                                   "<br> Assessment Unit ID: ", areas_mapper$assessmentunitidentifier,
+                                                   "<br> Status: ", areas_mapper$overallstatus)))
+    
+    # Return leaflet map of TADA WQ and its associated ATTAINS data
+    return(map)
+    
+  })
+  
+}

--- a/src/setup.R
+++ b/src/setup.R
@@ -18,7 +18,7 @@ package_loader <- function(x) {
   }
 }
 
-packages <- c("TADA", "tidyverse", "sf", "TADA", "urltools", "geojsonsf", "leaflet", "viridis")
+packages <- c("tidyverse", "sf", "urltools", "geojsonsf", "leaflet", "viridis", "remotes")
 
 lapply(packages, package_loader)
 

--- a/src/setup.R
+++ b/src/setup.R
@@ -1,0 +1,25 @@
+# get current TADA from Github:
+
+# if(!"remotes" %in% installed.packages()){
+#   install.packages("remotes")
+# }
+# 
+# remotes::install_github("USEPA/TADA", ref = "develop", dependencies = TRUE, force = TRUE)
+
+
+# Function to check for package installation, then install (if necessary) and load libraries.
+# Adapted from code developed by Caitlin Mothes, PhD.
+package_loader <- function(x) {
+  if (x %in% installed.packages()) {
+    library(x, character.only = TRUE)
+  } else {
+    install.packages(x)
+    library(x, character.only = TRUE)
+  }
+}
+
+packages <- c("TADA", "tidyverse", "sf", "TADA", "urltools", "geojsonsf", "leaflet", "viridis")
+
+lapply(packages, package_loader)
+
+rm(package_loader)

--- a/src/setup.R
+++ b/src/setup.R
@@ -21,5 +21,6 @@ package_loader <- function(x) {
 packages <- c("tidyverse", "sf", "urltools", "geojsonsf", "leaflet", "viridis", "remotes")
 
 lapply(packages, package_loader)
-
+# install TADA from GitHub using {remotes}
+remotes::install_github("USEPA/TADA", ref = "develop", dependencies = TRUE, force = TRUE)
 rm(package_loader)


### PR DESCRIPTION
I've started working on two separate functions:

1) A function that links TADA-style WQP data to its associated ATTAINS assessment units by doing a spatial join on catchment-level ATTAINS data.
2) A function that visualizes that linked assessment unit data and the WQP data. The leaflet code is in the same style as TADA's current TADA_OverviewMap() function.

I also added some narrative descriptions of what the functions are doing, and how ATTAINS is structured. This is mostly for you, in case you aren't super familiar with what ATTAINS is. (That being said, let me know if you have any questions!)

As the functions currently exist, they do not get at the exact ask of Cristina, but it's a start! Some things I know need work:

- I am not using the listed CRS's to transform the WQP observations into an sf object. I reckon we can modify the code @mbrousil wrote for AquaSat to parse each grouping of projections out and transform them, then remunge them. 
- The mapping colors and the map's overall look are arbitrary and definitely placeholders!

**My ask in this PR...** Could you make sure that the code runs without errors that stop the functions from returning their desired outputs? I have two TADA-style data sets that the functions are tested on, but would love it if you could play around with other locations and parameters to see if they work on other data.

Thank you!
Katie